### PR TITLE
Update dependency asm-all 5.0.2 to asm-commons 9.0 (and additionally asm-util 9.0 in dragome-callback-evictor)

### DIFF
--- a/dragome-bytecode-js-compiler/pom.xml
+++ b/dragome-bytecode-js-compiler/pom.xml
@@ -77,8 +77,8 @@
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-all</artifactId>
-      <version>5.0.2</version>
+      <artifactId>asm-commons</artifactId>
+      <version>9.0</version>
     </dependency>
     <dependency>
       <groupId>org.jdom</groupId>

--- a/dragome-callback-evictor/pom.xml
+++ b/dragome-callback-evictor/pom.xml
@@ -70,8 +70,13 @@
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-all</artifactId>
-      <version>5.0.2</version>
+      <artifactId>asm-commons</artifactId>
+      <version>9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>9.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/dragome-method-logger/pom.xml
+++ b/dragome-method-logger/pom.xml
@@ -81,8 +81,8 @@
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-all</artifactId>
-      <version>5.0.2</version>
+      <artifactId>asm-commons</artifactId>
+      <version>9.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/dragome-web/pom.xml
+++ b/dragome-web/pom.xml
@@ -111,8 +111,8 @@
 
   <dependency>
    <groupId>org.ow2.asm</groupId>
-   <artifactId>asm-all</artifactId>
-   <version>5.0.2</version>
+   <artifactId>asm-commons</artifactId>
+   <version>9.0</version>
   </dependency>
 
   <dependency>


### PR DESCRIPTION
To support Java bytecode versions **>= 53** for compiling classes to JavaScript

Solves #10 