### PR TITLE
Check for NullClassUnit in com.dragome.compiler.units.ClassUnit.setSuperUnit()

### DIFF
--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/units/ClassUnit.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/units/ClassUnit.java
@@ -47,6 +47,7 @@ import org.apache.commons.io.output.StringBuilderWriter;
 
 import com.dragome.commons.compiler.classpath.ClasspathFile;
 import com.dragome.compiler.DragomeJsCompiler;
+import com.dragome.compiler.NullClassUnit;
 import com.dragome.compiler.Project;
 import com.dragome.compiler.generators.DragomeJavaScriptGenerator;
 import com.dragome.compiler.type.Signature;
@@ -237,7 +238,7 @@ public class ClassUnit extends Unit
 
 	public void setSuperUnit(ClassUnit theSuperUnit)
 	{
-		if (superUnit != null)
+		if (superUnit != null && !(superUnit instanceof NullClassUnit))
 		{
 			superUnit.removeSubUnit(this);
 		}


### PR DESCRIPTION
When checking if there is a current `superUnit`. The simple `null`-check is not enough for ensuring that subsequent code will work

Related to #14

Solves #13